### PR TITLE
Attribute name property & traversing DOM elements

### DIFF
--- a/src/CssSelectorHelperWidget/CssSelectorHelperWidgetContext.xml
+++ b/src/CssSelectorHelperWidget/CssSelectorHelperWidgetContext.xml
@@ -15,9 +15,9 @@ J3me/JSb4Z++5yc2qRfyt/VqtQAAAABJRU5ErkJggg==
     </icon>
     <properties>
 		<property key="attributeContainingValue" allowNonPersistableEntities="true" type="attribute" required="true">
-			<caption>Attribute Value</caption>
+			<caption>Attribute value</caption>
 			<category>Common</category>
-			<description>The attribute that is used to set the CSS Classes (when no attributes the function is disabled)</description>
+			<description>The attribute that is used to set the CSS classes (when no attributes the function is disabled)</description>
 			<attributeTypes>
 				<attributeType name="String"/>
 				<attributeType name="Enum"/>
@@ -29,14 +29,24 @@ J3me/JSb4Z++5yc2qRfyt/VqtQAAAABJRU5ErkJggg==
 			<category>Common</category>
 			<description>To which element should the css be applied, the parent element or previous sibling.</description>
 			<enumerationValues>
-				<enumerationValue key="Sibling">Sibling</enumerationValue>
+				<enumerationValue key="Sibling">Previous sibling</enumerationValue>
 				<enumerationValue key="Parent">Parent</enumerationValue>
 			</enumerationValues>
 		</property>
+		<property key="parentLevels" type="integer" required="true" defaultValue="1">
+            <caption>Levels</caption>
+			<category>Common</category>
+            <description>In case of applying the css to the parent element, you can specify the amount of levels to traverse up in the DOM tree (selecting the parent element of the parent element)</description>
+        </property>     
         <property key="cssSelector" type="string" required="false">
             <caption>CSS selector</caption>
 			<category>Common</category>
             <description>When specified, this CSS selector is used to locate the element, rather than the direct parent or sibling</description>
-        </property>                		
+        </property>       
+        <property key="attributeName" type="string" required="true" defaultValue="cssSelectorHelper">
+            <caption>Attribute name</caption>
+			<category>Common</category>
+            <description>The name of the attribute that will be added to the DOM node (default: cssSelectorHelper)</description>
+        </property>             		
     </properties>
 </widget>

--- a/src/CssSelectorHelperWidget/widget/CssSelectorHelperWidgetContext.js
+++ b/src/CssSelectorHelperWidget/widget/CssSelectorHelperWidgetContext.js
@@ -46,14 +46,14 @@
 								node = refNodeList[0];
 								if (this.applyTo == 'Parent' ) {
 									if (node.parentNode) {
-										node.parentNode.setAttribute('cssSelectorHelper', attributeValue);
+										node.parentNode.setAttribute(this.attributeName, attributeValue);
 									} else {
 										console.warn('CssSelectorHelperWidget: No parent node found for CSS selector ' + this.cssSelector);
 									}
 								}
 								else {
 									if (node.previousSibling) {
-										node.previousSibling.setAttribute('cssSelectorHelper', attributeValue);
+										node.previousSibling.setAttribute(this.attributeName, attributeValue);
 									} else {
 										console.warn('CssSelectorHelperWidget: No previous sibling found for CSS selector ' + this.cssSelector);
 									}
@@ -65,15 +65,28 @@
 						} else {
 				
 							if (this.applyTo == 'Parent' ) {
-								if (this.domNode.parentNode) {
-									this.domNode.parentNode.setAttribute('cssSelectorHelper', attributeValue);
+								var parentNode = this.domNode.parentNode;
+
+								if (this.parentLevels > 1) {
+									for (var i = 1; i <= this.parentLevels; i++) { 
+										if (parentNode.parentNode) {
+											parentNode = parentNode.parentNode;
+										} else {
+											parentNode = null;
+											break;
+										}
+									}
+								} 
+
+								if (parentNode) {
+									parentNode.setAttribute(this.attributeName, attributeValue);
 								} else {
 									console.warn('CssSelectorHelperWidget: No parent node found');
 								}
 							}
 							else {
 								if (this.domNode.previousSibling) {
-									this.domNode.previousSibling.setAttribute('cssSelectorHelper', attributeValue);
+									this.domNode.previousSibling.setAttribute(this.attributeName, attributeValue);
 								} else {
 									console.warn('CssSelectorHelperWidget: No previous sibling found');
 								}


### PR DESCRIPTION
- Added widget property for the DOM attribute name (default:
cssSelectorHelper)
- Added widget property to configure the number of levels to traverse up
the DOM tree when applying to parent element (in order to be able to
target the parent element of the parent of the parent etc.)